### PR TITLE
Add `options` arguments for basic auth and ssl

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ push-docker-image myImage.tar.gz
 ```js
 const pushDockerImage = require('push-docker-image');
 
-pushDockerImage('/path/to/myImage.tar.gz')
+const options = {
+  auth: { username: 'user', password: 'password '},
+  ssl: false
+};
+
+// The `options` argument is optional
+pushDockerImage('/path/to/myImage.tar.gz', options)
     .then(() => console.log('Successfully uploaded.')
     .catch(() => console.log('Upload failed');
 ```

--- a/lib/createCustomFetch.js
+++ b/lib/createCustomFetch.js
@@ -1,0 +1,21 @@
+'use strict';
+
+const fetch = require('node-fetch');
+
+module.exports = function createCustomFetch({ username, password } = {}) {
+    // eslint-disable-next-line complexity
+    return function (url, options = {}) {
+        if (username && password) {
+            const basic = Buffer.from(`${username}:${password}`).toString('base64');
+            const authHeader = { Authorization: `Basic ${basic}` };
+
+            if (!options.headers) {
+                Object.assign(options, { headers: {} });
+            }
+
+            Object.assign(options.headers, authHeader);
+        }
+
+        return fetch(url, options);
+    };
+};

--- a/lib/pushDockerImage.js
+++ b/lib/pushDockerImage.js
@@ -70,8 +70,8 @@ async function upload(tempDir, { auth, ssl }) {
                 args[1].headers = {};
             }
 
-            const auth = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
-            args[1].headers['Authorization'] = auth;
+            const header = `Basic ${Buffer.from(`${auth.username}:${auth.password}`).toString('base64')}`;
+            args[1].headers.Authorization = header;
         }
 
         return fetch(...args);

--- a/lib/pushDockerImage.js
+++ b/lib/pushDockerImage.js
@@ -31,6 +31,10 @@ const chunkSize = 16 * 1024 * 1024;
 const readStreamOptions = { highWaterMark: chunkSize };
 
 async function compressLayer(layerPath) {
+    if (layerPath.endsWith('.gz')) {
+        return layerPath;
+    }
+
     const readStream = fs.createReadStream(layerPath, readStreamOptions);
     const writeSteam = fs.createWriteStream(`${layerPath}.gz`, { encoding: 'binary' });
     const transformStream = zlib.createGzip({ chunkSize });
@@ -52,16 +56,38 @@ function createReporter(layerId) {
     };
 }
 
-async function upload(tempDir) {
+async function upload(tempDir, { auth, ssl }) {
     const imageManifest = require(path.join(tempDir, './manifest.json'));
     const imageDetails = extractImageDetails(imageManifest);
 
-    const registryClient = createRegistryClient(imageDetails, fetch);
+    const customFetch = (...args) => {
+        if (auth && auth.username && auth.password) {
+            if (!args[1]) {
+                args[1] = {};
+            }
+
+            if (!args[1].headers) {
+                args[1].headers = {};
+            }
+
+            const auth = `Basic ${Buffer.from(`${username}:${password}`).toString('base64')}`;
+            args[1].headers['Authorization'] = auth;
+        }
+
+        return fetch(...args);
+    };
+
+    const registryClient = createRegistryClient(imageDetails, customFetch, { ssl });
 
     const uploadAllLayerPromises = imageDetails.layers.map(async (relativeLayerPath) => {
         const [ layerId ] = relativeLayerPath.split('/');
         const layerPath = path.join(tempDir, relativeLayerPath);
         const compressedLayerPath = await compressLayer(layerPath);
+
+        console.log('Layer Path:', layerPath);
+        console.log('Upload Layer:', compressedLayerPath);
+        console.log('Joined Paths', relativeLayerPath);
+        console.log('\n');
 
         const hash = await hasha.fromFile(compressedLayerPath, { algorithm: 'sha256' });
         const digest = `sha256:${hash}`;
@@ -82,13 +108,13 @@ async function upload(tempDir) {
     await registryClient.createImageDistributionManifest(layerResults, imageConfigResult);
 }
 
-module.exports = async function main(dockerImageTarFile) {
+module.exports = async function main(dockerImageTarFile, { auth, ssl } = {}) {
     const tempDir = await createTempDir();
 
     try {
         await extractArchive(dockerImageTarFile, tempDir);
 
-        await upload(tempDir);
+        await upload(tempDir, { auth, ssl });
 
         // eslint-disable-next-line no-console
         console.log('Image successfully uploaded.');

--- a/lib/pushDockerImage.js
+++ b/lib/pushDockerImage.js
@@ -8,10 +8,10 @@ const pipeStreamsToPromise = require('pipe-streams-to-promise');
 const tmp = require('tmp');
 const { promisify } = require('util');
 const rimraf = require('rimraf');
-const fetch = require('node-fetch');
 const hasha = require('hasha');
 const extractImageDetails = require('./extractImageDetails');
 const createRegistryClient = require('./registryClient');
+const createCustomFetch = require('./createCustomFetch');
 const formatBytes = require('pretty-bytes');
 const zlib = require('zlib');
 
@@ -60,25 +60,10 @@ async function upload(tempDir, { auth, ssl }) {
     const imageManifest = require(path.join(tempDir, './manifest.json'));
     const imageDetails = extractImageDetails(imageManifest);
 
-    const customFetch = (...args) => {
-        if (auth && auth.username && auth.password) {
-            if (!args[1]) {
-                args[1] = {};
-            }
-
-            if (!args[1].headers) {
-                args[1].headers = {};
-            }
-
-            const header = `Basic ${Buffer.from(`${auth.username}:${auth.password}`).toString('base64')}`;
-            args[1].headers.Authorization = header;
-        }
-
-        return fetch(...args);
-    };
-
+    const customFetch = createCustomFetch(auth);
     const registryClient = createRegistryClient(imageDetails, customFetch, { ssl });
 
+    // eslint-disable-next-line max-statements
     const uploadAllLayerPromises = imageDetails.layers.map(async (relativeLayerPath) => {
         const [ layerId ] = relativeLayerPath.split('/');
         const layerPath = path.join(tempDir, relativeLayerPath);

--- a/lib/pushDockerImage.js
+++ b/lib/pushDockerImage.js
@@ -69,11 +69,6 @@ async function upload(tempDir, { auth, ssl }) {
         const layerPath = path.join(tempDir, relativeLayerPath);
         const compressedLayerPath = await compressLayer(layerPath);
 
-        console.log('Layer Path:', layerPath);
-        console.log('Upload Layer:', compressedLayerPath);
-        console.log('Joined Paths', relativeLayerPath);
-        console.log('\n');
-
         const hash = await hasha.fromFile(compressedLayerPath, { algorithm: 'sha256' });
         const digest = `sha256:${hash}`;
         const readStream = fs.createReadStream(compressedLayerPath, readStreamOptions);

--- a/lib/registryClient.js
+++ b/lib/registryClient.js
@@ -8,7 +8,7 @@ const pipeStreamsToPromise = require('pipe-streams-to-promise');
 const createBlobWriteStream = require('./createBlobWriteStream');
 const buildDistributionManifest = require('./buildDistributionManifest');
 
-module.exports = function createRegistryClient(imageDetails, fetch, { ssl }) {
+module.exports = function createRegistryClient(imageDetails, fetch, { ssl } = {}) {
     const protocol = ssl ? 'https' : 'http';
     const registryUrl = `${protocol}://${imageDetails.registry}`;
     const { repository, tag } = imageDetails;

--- a/lib/registryClient.js
+++ b/lib/registryClient.js
@@ -8,8 +8,9 @@ const pipeStreamsToPromise = require('pipe-streams-to-promise');
 const createBlobWriteStream = require('./createBlobWriteStream');
 const buildDistributionManifest = require('./buildDistributionManifest');
 
-module.exports = function createRegistryClient(imageDetails, fetch) {
-    const registryUrl = `http://${imageDetails.registry}`;
+module.exports = function createRegistryClient(imageDetails, fetch, { ssl }) {
+    const protocol = ssl ? 'https' : 'http';
+    const registryUrl = `${protocol}://${imageDetails.registry}`;
     const { repository, tag } = imageDetails;
 
     async function initiateBlobUpload() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7073,6 +7073,12 @@
         "execa": "^0.7.0"
       }
     },
+    "test-listen": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/test-listen/-/test-listen-1.1.0.tgz",
+      "integrity": "sha512-OyEVi981C1sb9NX1xayfgZls3p8QTDRwp06EcgxSgd1kktaENBW8dO15i8v/7Fi15j0IYQctJzk5J+hyEBId2w==",
+      "dev": true
+    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2079,9 +2079,9 @@
           }
         },
         "js-yaml": {
-          "version": "3.13.0",
-          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-          "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+          "version": "3.13.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+          "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
           "dev": true,
           "requires": {
             "argparse": "^1.0.7",
@@ -3851,9 +3851,9 @@
       "dev": true
     },
     "js-yaml": {
-      "version": "3.12.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.0.tgz",
-      "integrity": "sha512-PIt2cnwmPfL4hKNwqeiuz4bKfnzHTBv6HyVgjahA6mPLwPDzjDWrplJBMjHUFxku/N3FlmrbyPclad+I+4mJ3A==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "eslint-config-holidaycheck": "0.13.1",
     "nyc": "13.3.0",
     "pr-log": "3.1.0",
-    "sinon": "7.3.0"
+    "sinon": "7.3.0",
+    "test-listen": "1.1.0"
   },
   "nyc": {
     "all": true,

--- a/test/unit/lib/createCustomFetchSpec.js
+++ b/test/unit/lib/createCustomFetchSpec.js
@@ -1,0 +1,46 @@
+'use strict';
+
+const test = require('ava');
+const http = require('http');
+const createCustomFetch = require('../../../lib/createCustomFetch');
+
+test('verify auth header', async (t) => {
+    const port = 3000;
+
+    const server = http.createServer((req, res) => {
+        res.end(req.headers.authorization);
+    });
+
+    server.listen(port);
+
+    const hasAuth = await new Promise(async (resolve) => {
+        const fetch = createCustomFetch({ username: 'test', password: 'test' });
+        const res = await fetch(`http://localhost:${port}`);
+        resolve(Boolean(await res.text()));
+    });
+
+    const hasNoAuth = await new Promise(async (resolve) => {
+        const fetch = createCustomFetch();
+        const res = await fetch(`http://localhost:${port}`);
+        resolve(Boolean(await res.text()));
+    });
+
+    const hasAuthWithHeader = await new Promise(async (resolve) => {
+        const fetch = createCustomFetch({ username: 'test', password: 'test' });
+        const res = await fetch(`http://localhost:${port}`, { headers: { 'x-test': 1 } });
+        resolve(Boolean(await res.text()));
+    });
+
+    const hasNoAuthWithHeader = await new Promise(async (resolve) => {
+        const fetch = createCustomFetch();
+        const res = await fetch(`http://localhost:${port}`, { headers: { 'x-test': 1 } });
+        resolve(Boolean(await res.text()));
+    });
+
+    server.close();
+
+    t.is(hasAuth, true);
+    t.is(hasNoAuth, false);
+    t.is(hasAuthWithHeader, true);
+    t.is(hasNoAuthWithHeader, false);
+});

--- a/test/unit/lib/registryClientSpec.js
+++ b/test/unit/lib/registryClientSpec.js
@@ -208,3 +208,17 @@ test('calls the onProgress callback immediately when blob already exists', async
     t.is(onProgress.callCount, 1);
     t.deepEqual(onProgress.firstCall.args, [ { size: 42, done: true, alreadyExists: true } ]);
 });
+
+test('calls the onProgress callback immediately when blob already exists with SSL', async (t) => {
+    const headers = new Headers({ 'Content-Length': 42 });
+    const fetch = sinon.stub().resolves({ status: 200, headers });
+
+    const client = createRegistryClient(imageDetails, fetch, { ssl: true });
+    const readStream = new Readable();
+
+    const onProgress = sinon.stub();
+    await client.uploadBlob(readStream, 'anyDigest', { onProgress }).catch(noop);
+
+    t.is(onProgress.callCount, 1);
+    t.deepEqual(onProgress.firstCall.args, [ { size: 42, done: true, alreadyExists: true } ]);
+});


### PR DESCRIPTION
This PR adds an `options` argument to the `main` function and introduces the `auth` option and the `ssl` option to give more control.

It will also check for already gzipped layers and ignore those.

We are currently trying to find a way to push an image to a registry without docker and this could work with those additional changes.